### PR TITLE
Admin init

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -31,7 +31,7 @@
     width: 72px;
     height: 32px;
     text-align: center;
-     box-shadow: 0px 6px 6px rgba(0, 0, 0, 0.03), 0px 6px 6px rgba(0, 0, 0, 0.03);
+    box-shadow: 0px 6px 6px rgba(0, 0, 0, 0.03), 0px 6px 6px rgba(0, 0, 0, 0.03);
     a {
       color: $t-white;
       line-height: 2.15;

--- a/app/assets/stylesheets/components/_talalla-components.scss
+++ b/app/assets/stylesheets/components/_talalla-components.scss
@@ -36,17 +36,17 @@
     align-items: center;
   }
 
-    .avatar-talalla img {
-      width: 88px;
-      height: 88px;
-      border-radius: 50%;
-      object-fit: cover;
-      box-shadow: 0px 12px 12px rgba(0, 0, 0, 0.05), 0px 12px 12px rgba(0, 0, 0, 0.05);
-      margin-bottom: 16px;
-    }
-    .description-talalla {
-      padding-left: 8px;
-    }
+  .avatar-talalla img {
+    width: 88px;
+    height: 88px;
+    border-radius: 50%;
+    object-fit: cover;
+    box-shadow: 0px 12px 12px rgba(0, 0, 0, 0.05), 0px 12px 12px rgba(0, 0, 0, 0.05);
+    margin-bottom: 16px;
+  }
+  .description-talalla {
+    padding-left: 8px;
+  }
 }
 
 .second-card {
@@ -90,4 +90,8 @@
   background-color: white;
   box-shadow: 0px 12px 12px rgba(0, 0, 0, 0.05), 0px 12px 12px rgba(0, 0, 0, 0.05);
   padding: 16px;
+  margin-bottom: 48px;
+  .stats {
+    text-align: center;
+  }
 }

--- a/app/assets/stylesheets/components/_talalla-components.scss
+++ b/app/assets/stylesheets/components/_talalla-components.scss
@@ -93,5 +93,40 @@
   margin-bottom: 48px;
   .stats {
     text-align: center;
+    min-width: 100px;
+    .link-icon {
+      // transition: all 0.4s ease-in-out; zoom for some reason not working?
+      &:hover{
+        text-decoration: none;
+        // transform: scale(1.1);
+        font-weight: bolder;
+      }
+    }
+    h2 {
+      margin: 16px 0 0 0;
+    }
+  }
+  .more-button{
+    margin: 0 190px;
+    // margin: 0 auto;
+  }
+
+  .edit-details {
+    min-width: 33%;
+    text-align: center;
+    margin: 4px;
+    .fa-users {
+      color: $green;
+      &:hover {
+        color: darker;
+      }
+    }
+    .fa-users-one {
+      color: $t-gray;
+    }
+
+    .link:hover{
+      text-decoration: none;
+    }
   }
 }

--- a/app/assets/stylesheets/dashboards/_community.scss
+++ b/app/assets/stylesheets/dashboards/_community.scss
@@ -155,10 +155,10 @@
 
 .add-button {
   border-radius: 50%;
-  border-color: $t-blue;
+  border-color: $green;
   border-style: solid;
   padding: 8px;
-  color: $t-blue;
+  color: $green;
   transition: all 0.4s ease-in-out;
   &:hover {
     cursor: pointer;

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -7,3 +7,4 @@
 @import "personal_dashboard";
 @import "about";
 @import "studio_world";
+@import "admin_dashboard";

--- a/app/assets/stylesheets/pages/_personal_dashboard.scss
+++ b/app/assets/stylesheets/pages/_personal_dashboard.scss
@@ -49,7 +49,6 @@
 }
 
 .calendar-notes-container {
-  margin-top: 48px;
   padding: 16px;
   background-color: white;
   box-shadow: 0px 12px 12px rgba(0, 0, 0, 0.05), 0px 12px 12px rgba(0, 0, 0, 0.05);

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,6 +18,7 @@ class PagesController < ApplicationController
     @teachers = @users.where(is_teacher: true)
     @students = @users.where(is_teacher: false).where(is_admin: false)
     @lessons = Lesson.where(studio: current_user.studio)
+    @studio = current_user.studio
     # @subscriptions = Subscription.where(studio: current_user.studio)
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,7 +19,7 @@ class PagesController < ApplicationController
     @students = @users.where(is_teacher: false).where(is_admin: false)
     @lessons = Lesson.where(studio: current_user.studio)
     @studio = current_user.studio
-    # @subscriptions = Subscription.where(studio: current_user.studio)
+    @subscriptions = current_user.studio.subscriptions
   end
 
   def students_index

--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -1,3 +1,4 @@
+
 class StudiosController < ApplicationController
   include Pundit
   after_action :verify_authorized, except: [:index, :show, :community], unless: :skip_pundit?
@@ -18,9 +19,11 @@ class StudiosController < ApplicationController
   end
 
   def edit
+    authorize @studio
   end
 
   def update
+    authorize @studio
     @studio.update(studio_params)
     if @studio.save
       redirect_to admin_dashboard_path

--- a/app/views/pages/admin_dashboard.html.erb
+++ b/app/views/pages/admin_dashboard.html.erb
@@ -59,7 +59,7 @@
           </div>
           <div class="edit-details">
             <%= link_to studio_lessons_path(@studio), class: "link" do %>
-              <h1><i class="fas fa-users"></i></h1>
+              <h1><i class="fas fa-users fa-users-one"></i></h1>
               <p>add, edit, and manage lessons</p>
               <p class="btn btn-primary btn-sm">edit</p>
             <% end %>

--- a/app/views/pages/admin_dashboard.html.erb
+++ b/app/views/pages/admin_dashboard.html.erb
@@ -11,35 +11,97 @@
     <div class="right-pannel">
       <p>I am the right pannel</p>
       <h1><%= @studio.name %>: an overview</h1>
-      <div class="third-card d-flex justify-content-around">
-        <div class="stats">
-          <%= link_to do %>
-            <h2>XX</h2> <br>
-            <p>and here</p>
-          <% end %>
-        </div>
-        <div class="stats">
-          <h2>XX</h2> <br>
-          <p>and here</p>
-        </div>
-        <div class="stats">
-          <h2>XX</h2> <br>
-          <p>and here</p>
-        </div>
-        <div class="stats">
-          <h2>XX</h2> <br>
-          <p>and here</p>
-        </div>
-      </div>
       <div class="third-card">
-        <p>I am also a third card<br>editing options with icons will be displayed in here</p>
+        <div class="d-flex justify-content-around">
+          <div class="stats">
+            <%= link_to students_path, class: "link-icon" do %>
+              <h2><%= @students.count %></h2> <br>
+              <p>Yogis</p>
+            <% end %>
+          </div>
+          <div class="stats">
+            <%= link_to teachers_path, class: "link-icon" do %>
+              <h2><%= @teachers.count %></h2> <br>
+              <p>Teachers</p>
+            <% end %>
+          </div>
+          <div class="stats">
+              <% sum = 0 %>
+              <% @subscriptions.each do |subscription| %>
+                <% sum += (subscription.orders.count * subscription.amount).to_i %>
+              <% end %>
+            <%= link_to studio_subscriptions_path(@studio), class: "link-icon" do %>
+              <h2><%= sum %> IDR</h2> <br>
+              <p>Revenue</p>
+            <% end %>
+          </div>
+          <div class="stats">
+            <%= link_to studio_lessons_path(@studio), class: "link-icon" do %>
+              <h2><%= @lessons.count %></h2> <br>
+              <p>Lessons</p>
+            <% end %>
+          </div>
+        </div>
+        <!-- where is this link supposed to lead to? -->
+        <%= link_to "more information", orders_path, class: "btn btn-primary btn-sm more-button" %>
+      </div>
+
+      <!-- bottom right -- many editing actions -->
+      <h1>Any header we'd like</h1>
+      <div class="third-card">
+        <div class="top-of-third d-flex justify-content-between">
+          <div class="edit-details">
+            <h1><i class="fas fa-users fa-users-one"></i></h1>
+            <p>manage my studio information</p>
+            <%= link_to edit_studio_path(@studio), class: "link" do %>
+              <p class="btn btn-primary btn-sm">edit</p>
+            <% end %>
+          </div>
+          <div class="edit-details">
+            <%= link_to studio_lessons_path(@studio), class: "link" do %>
+              <h1><i class="fas fa-users"></i></h1>
+              <p>add, edit, and manage lessons</p>
+              <p class="btn btn-primary btn-sm">edit</p>
+            <% end %>
+          </div>
+          <div class="edit-details">
+            <%= link_to studio_events_path(@studio), class: "link" do %>
+              <h1><i class="fas fa-users"></i></h1>
+              <p>add, edit, and manage events</p>
+              <p class="btn btn-primary btn-sm">edit</p>
+            <% end %>
+          </div>
+        </div>
+        <div class="bottom-of-third d-flex">
+          <div class="edit-details">
+            <%= link_to students_path, class: "link" do %>
+              <h1><i class="fas fa-users"></i></h1>
+              <p>manage my students</p>
+              <p class="btn btn-primary btn-sm">edit</p>
+            <% end %>
+          </div>
+          <div class="edit-details">
+            <%= link_to teachers_path, class: "link" do %>
+              <h1><i class="fas fa-users"></i></h1>
+              <p>manage my teachers</p>
+              <p class="btn btn-primary btn-sm">edit</p>
+            <% end %>
+          </div>
+          <div class="edit-details">
+            <%= link_to studio_subscriptions_path(@studio), class: "link" do %>
+              <h1><i class="fas fa-users"></i></h1>
+              <p>add and edit the available subscriptions</p>
+              <p class="btn btn-primary btn-sm">edit</p>
+            <% end %>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </div>
 
 
-
+<!-- almost all available paths -->
 <!--   <hr>
   <%#= link_to "Your students", students_path%>
   <br>

--- a/app/views/pages/admin_dashboard.html.erb
+++ b/app/views/pages/admin_dashboard.html.erb
@@ -1,35 +1,70 @@
 <div class="container">
+  <div class="main-container">
+    <div class="left-pannel">
+      <p>I am the left pannel</p>
+      <h1>Upcoming classes at <%= @studio.name %></h1>
+      <div class="first-card">
+        <p>I am the first card.<br>I will be displaying the upcoming classes at the <%= @studio.name %>.<br>We will see whether display: flex; is the best choice for me.</p>
+      </div>
+    </div>
+
+    <div class="right-pannel">
+      <p>I am the right pannel</p>
+      <h1><%= @studio.name %>: an overview</h1>
+      <div class="third-card d-flex justify-content-around">
+        <div class="stats">
+          <%= link_to do %>
+            <h2>XX</h2> <br>
+            <p>and here</p>
+          <% end %>
+        </div>
+        <div class="stats">
+          <h2>XX</h2> <br>
+          <p>and here</p>
+        </div>
+        <div class="stats">
+          <h2>XX</h2> <br>
+          <p>and here</p>
+        </div>
+        <div class="stats">
+          <h2>XX</h2> <br>
+          <p>and here</p>
+        </div>
+      </div>
+      <div class="third-card">
+        <p>I am also a third card<br>editing options with icons will be displayed in here</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<!--   <hr>
+  <%#= link_to "Your students", students_path%>
   <br>
-  <h1>Admin dashboard</h1>
   <br>
-  <h3>Welcome <%= current_user.first_name%>! </h3>
-  <p><strong>Manage your yoga studio</strong></p>
-  <hr>
-  <%= link_to "Your students", students_path%>
+  <%#= link_to "Your teachers", teachers_path%>
+  <%#= link_to "Add", new_teacher_path%>
   <br>
   <br>
-  <%= link_to "Your teachers", teachers_path%>
-  <%= link_to "Add", new_teacher_path%>
+  <%#= link_to "Your subscriptions", studio_subscriptions_path(current_user.studio_id)%>
+  <%#= link_to "Add", new_studio_subscription_path(current_user.studio_id)%>
   <br>
   <br>
-  <%= link_to "Your subscriptions", studio_subscriptions_path(current_user.studio_id)%>
-  <%= link_to "Add", new_studio_subscription_path(current_user.studio_id)%>
+  <%#= link_to "Your lessons", studio_lessons_path(current_user.studio_id)%>
+  <%#= link_to "Add", new_lesson_path%>
   <br>
   <br>
-  <%= link_to "Your lessons", studio_lessons_path(current_user.studio_id)%>
-  <%= link_to "Add", new_lesson_path%>
+  <%#= link_to "Your events", studio_events_path(current_user.studio_id)%>
+  <%#= link_to "Add", new_studio_event_path(current_user.studio_id)%>
   <br>
   <br>
-  <%= link_to "Your events", studio_events_path(current_user.studio_id)%>
-  <%= link_to "Add", new_studio_event_path(current_user.studio_id)%>
-  <br>
-  <br>
-  <%= link_to "Your studio", studio_path(current_user.studio_id)%>
-  <%= link_to "change studio details", edit_studio_path(current_user.studio_id)%>
+  <%#= link_to "Your studio", studio_path(current_user.studio_id)%>
+  <%#= link_to "change studio details", edit_studio_path(current_user.studio_id)%>
 
   <hr>
-  <p><%=  link_to "all orders", orders_path %>
+  <p><%#=  link_to "all orders", orders_path %>
 
   </p>
-  <hr>
-</div>
+  <hr> -->


### PR DESCRIPTION
I used the pre-defined talalla-components to format the page --> consistency across pages guaranteed:
- three divs make the basic layout

Left side is blank (the schedule will be inserted there)

Right side, top: 
- displays the key values of the studio (not monthly, just overall)
- we have to decide where the more information button is supposed to lead to?

Right side, bottom:
- icons should be replaced by individually fitting icons
- the top three show all the versions we could display it as (and which part will be clickable)